### PR TITLE
⚡ Bolt: [performance improvement] Lazy-load route components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-10 - Code splitting lazy-loaded routes with Suspense
+**Learning:** React Router routes without lazy loading cause the entire application to be loaded initially, creating a large bundle size and slower perceived load times. In an app where a user might only visit one tab/route at a time, splitting the components using `React.lazy()` dramatically decreases the initial JS bundle size.
+**Action:** Always check if the main `Routes` block uses `React.lazy()` and `<Suspense>` for its component mapping, and implement code-splitting if not already done.

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,13 @@
 import { AppBar, MenuItem, Toolbar, Typography, useMediaQuery, Drawer, List, ListItem, ListItemText, IconButton, Theme } from "@mui/material";
 import { Link, Routes, Route, BrowserRouter as Router } from "react-router-dom";
 import MenuIcon from '@mui/icons-material/Menu';
-import { useState } from 'react';
+import { useState, lazy, Suspense } from 'react';
 import logo from '../assets/favicon_io/android-chrome-512x512.png';
-import NasaAPOD from "./APOD";
-import MarsPhotos from "./MarsPhotos";
-import NASANews from "./NASANews";
+import { CircularProgress, Box } from '@mui/material';
+
+const NasaAPOD = lazy(() => import('./APOD'));
+const MarsPhotos = lazy(() => import('./MarsPhotos'));
+const NASANews = lazy(() => import('./NASANews'));
 
 const CommonAppBar = () => {
     const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'));
@@ -54,11 +56,14 @@ const App = () => {
     return (
         <Router>
             <CommonAppBar />
-            <Routes>
-                <Route path="/apod" element={<NasaAPOD />} />
-                <Route path="/marsRoverPhotos" element={<MarsPhotos />} />
-                <Route path="/nasaNews" element={<NASANews />} /> {/* Add the new route */}
-            </Routes>
+            {/* ⚡ Bolt: Added Suspense boundary for lazy-loaded route components. This enables code splitting for each route, significantly reducing the initial bundle size. */}
+            <Suspense fallback={<Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}><CircularProgress /></Box>}>
+                <Routes>
+                    <Route path="/apod" element={<NasaAPOD />} />
+                    <Route path="/marsRoverPhotos" element={<MarsPhotos />} />
+                    <Route path="/nasaNews" element={<NASANews />} /> {/* Add the new route */}
+                </Routes>
+            </Suspense>
         </Router>
     );
 };


### PR DESCRIPTION
💡 **What**: The optimization implemented is code-splitting the application routes in `src/components/Header.tsx` by replacing static imports with dynamic ones using `React.lazy()` and wrapping the `Routes` tree with a `<Suspense>` component.

🎯 **Why**: The performance problem it solves is a large initial bundle size and slow initial rendering. By statically importing all route components, everything is bundled into the initial payload even if the user never visits those routes. This change dramatically decreases the initial JS payload since users will only load the components for routes they actually navigate to.

📊 **Impact**: Expected performance improvement includes reducing the initial bundle size significantly and thus providing a faster time-to-interactive.

🔬 **Measurement**: How to verify the improvement: Build the application with `npm run build` before and after the change, and observe that the chunk distribution favors smaller individual asset sizes rather than one massive index.js bundle. Start the local server (`npm run preview`) and verify the routes render correctly with their loading fallback.

---
*PR created automatically by Jules for task [17442567102483899389](https://jules.google.com/task/17442567102483899389) started by @jlthompson96*